### PR TITLE
Fix column/data mismatch in DataFrame serialization

### DIFF
--- a/mlb_stats_mcp/tools/pybaseball_supp_tools.py
+++ b/mlb_stats_mcp/tools/pybaseball_supp_tools.py
@@ -41,6 +41,7 @@ def _convert_dataframe_to_dict(df: pd.DataFrame) -> Dict[str, Any]:
 
     try:
         df_clean = df.copy()
+        df_clean = df_clean.reset_index()
         df_clean = df_clean.where(pd.notnull(df_clean), None)
         df_clean = df_clean.replace("", None)
         records = df_clean.to_dict(orient="records")


### PR DESCRIPTION
_convert_dataframe_to_dict() returns df.columns.tolist() from the original df, but the actual records are built from df_clean via to_dict(orient="records"). When df has a non-default index, df_clean gains an extra column once normalized that the returned columns list doesn't account for, so callers relying on columns to label the rows in data get a mismatch. Adding reset_index() to df_clean before serialization keeps the two in sync.